### PR TITLE
Update SpeechRecorder.cpp

### DIFF
--- a/Source/Speechly/Private/SpeechRecorder.cpp
+++ b/Source/Speechly/Private/SpeechRecorder.cpp
@@ -87,8 +87,8 @@ void FSpeechRecorder::Start()
 		FAudioCaptureDeviceParams DeviceParams;
 		DeviceParams.bUseHardwareAEC = OutInfo.bSupportsHardwareAEC;
 		DeviceParams.DeviceIndex = INDEX_NONE;
-		FOnCaptureFunction OnCaptureFunction = [this](const float* InAudio, int32 NumFrames, int32 NumChannels, int32 SampleRate, double StreamTime, bool bOverFlow) {
-			return this->OnAudioCapture(InAudio, NumFrames, NumChannels, SampleRate, StreamTime, bOverFlow);
+		FOnCaptureFunction OnCaptureFunction = [this](const float* InAudio, int32 NumFrames, int32 NumChannels, int32 _SampleRate, double StreamTime, bool bOverFlow) {
+			return this->OnAudioCapture(InAudio, NumFrames, NumChannels, _SampleRate, StreamTime, bOverFlow);
 		};
 		verifyf(AudioCapture.OpenCaptureStream(DeviceParams, OnCaptureFunction, NumFramesDesired), TEXT("Could not open capture stream"));
 


### PR DESCRIPTION
Renamed lambda param `SampleRate` to `_SampleRate` to prevent it from shadowing the class field of same name

```
In file included from /Users/arzga/Documents/ue4example/Plugins/Speechly/Intermediate/Build/Mac/x86_64/UE4Editor/Development/Speechly/Module.Speechly.cpp:5:
/Users/arzga/Documents/ue4example/Plugins/Speechly/Source/Speechly/Private/SpeechRecorder.cpp:90:113: error: declaration shadows a field of 'FSpeechRecorder' [-Werror,-Wshadow]
                FOnCaptureFunction OnCaptureFunction = [this](const float* InAudio, int32 NumFrames, int32 NumChannels, int32 SampleRate, double StreamTime, bool bOverFlow) {
                                                                                                                              ^
/Users/arzga/Documents/ue4example/Plugins/Speechly/Source/Speechly/Public/SpeechRecorder.h:38:6: note: previous declaration is here
        int SampleRate;
            ^
1 error generated.
```